### PR TITLE
Kramdown の smart_quotes 機能を無効にする

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ exclude:
 
 # Build settings
 markdown: kramdown
+kramdown:
+  smart_quotes: ["apos", "apos", "quot", "quot"]
 permalink: /:categories/:year/:month/:day/:title
 future: true
 timezone: Asia/Tokyo


### PR DESCRIPTION
KaTeX と干渉して $a'$ のような表記が崩れるのを防ぐため

close #63 
cc @rsk0315