### PR TITLE
略称を「ア辞典」で固定する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Kyopro Encyclopedia of Algorithms
+# Kyopro Encyclopedia of Algorithms (ア辞典)
 
 <https://kmyk.github.io/algorithm-encyclopedia/>
 
 ## これなに
 
-競プロ用のアルゴリズムの解説を集めた百科辞典を目指しているサイトです。(試験運用中)
+競プロ用のアルゴリズムの解説を集めた百科辞典を目指しているサイトです。
 
 ### 内容の方針
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,15 +29,15 @@
   <body>
     <div class="container-lg px-3 my-5 markdown-body">
         <h1>
-            {% if page.title and page.title != site.title %}
+            {% if page.title contains site.title %}
+                {{ page.title }}
+            {% elsif site.title %}
                 {% if page.algorithm.level %}<span class="rating-color-{{ page.algorithm.level }}">&#x25C9;</span>{% endif %}
                 {{ page.title }}
 
                 <div class="mt-auto float-right">
                   <a class="toppage-link" href="{{ site.url | relative_url }}">{{ site.title }}</a>
                 </div>
-            {% elsif site.title %}
-                {{ site.title }}
             {% endif %}
         </h1>
 

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# Kyopro Encyclopedia of Algorithms
+# Kyopro Encyclopedia of Algorithms (ア辞典)
 
 これは競プロの知見を収集するための査読付きの半共有 wiki である。
 アルゴリズムについての説明が中心となっている。なお、データ構造については [scrapbox.io/data-structures](https://scrapbox.io/data-structures/) (通称: デ wiki) を利用するのがよいだろう。


### PR DESCRIPTION
はっきりさせておいた方が呼びやすい