### PR TITLE
spaceの修正

### DIFF
--- a/_algorithms/fast-fourier-transform.md
+++ b/_algorithms/fast-fourier-transform.md
@@ -11,9 +11,9 @@ algorithm:
   space_complexity:
   aliases: FFT
   level: yellow
-description: 高速Fourier変換とは、離散Fourier変換を $O(n \log n)$ で行なうアルゴリズムである。高速な多項式乗算の実装などに用いられる。
+description: 高速 Fourier 変換とは、離散 Fourier 変換を $O(n \log n)$ で行なうアルゴリズムである。高速な多項式乗算の実装などに用いられる。
 draft: true
 draft_urls:
 ---
 
-# 高速Fourier変換
+# 高速 Fourier 変換

--- a/_algorithms/fast-kitamasa-method.md
+++ b/_algorithms/fast-kitamasa-method.md
@@ -16,4 +16,4 @@ draft: true
 draft_urls: []
 ---
 
-# 高速Kitamasa法
+# 高速 Kitamasa 法


### PR DESCRIPTION
英文字と日本語の間にspaceが入っていない関係で，ソートの順番がずれていたりしていたので，(高速 zeta 変換が高速 Fourier 変換の前に来ていた)スペースをいれて修正しました．
