### PR TITLE
目次の見出しにメタデータを表示する

### DIFF
--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -9,6 +9,13 @@
     font-weight: normal;
 }
 
+// the details in the index page
+.algorithm-index-details > summary::-webkit-details-marker {
+    color: grey;
+    font-size: 60%;
+}
+
+
 // algorithm data
 .algorithm-data {
     color: grey;

--- a/index.md
+++ b/index.md
@@ -31,7 +31,32 @@
                 {% for url in entry.draft_urls %} <a href="{{ url }}" class="link-external">{% octicon link-external height:16 %}</a>{% endfor %}
             {% endif %}
         </dt>
-        <dd>{{ entry.description }}</dd>
+        <dd>
+            {% capture algorithm_data %}
+                {% if entry.algorithm.input %}<dt>input</dt><dd>{{ entry.algorithm.input }}</dd>{% endif %}
+                {% if entry.algorithm.pre_condition %}<dt>pre-condition</dt><dd>{{ entry.algorithm.pre_condition }}</dd>{% endif %}
+                {% if entry.algorithm.output %}<dt>output</dt><dd>{{ entry.algorithm.output }}</dd>{% endif %}
+                {% if entry.algorithm.post_condition %}<dt>post-condition</dt><dd>{{ entry.algorithm.post_condition }}</dd>{% endif %}
+                {% if entry.algorithm.condition %}<dt>condition</dt><dd>{{ entry.algorithm.condition }}</dd>{% endif %}
+                {% if entry.algorithm.time_complexity %}<dt>time complexity</dt><dd>{{ entry.algorithm.time_complexity }}</dd>{% endif %}
+                {% if entry.algorithm.space_complexity %}<dt>space complexity</dt><dd>{{ entry.algorithm.space_complexity }}</dd>{% endif %}
+            {% endcapture %}
+            {% assign stripped_algorithm_data = algorithm_data | strip %}
+            {% if stripped_algorithm_data == "" %}
+                {{ entry.description }}
+            {% else %}
+                <details class="algorithm-index-details">
+                    <summary>
+                        {{ entry.description }}
+                    </summary>
+                    <div class="algorithm-data">
+                        <dl>
+                            {{ algorithm_data }}
+                        </dl>
+                    </div>
+                </details>
+            {% endif %}
+        </dd>
     {% endunless %}
 {% endfor %}
 </dl>

--- a/index.md
+++ b/index.md
@@ -42,9 +42,7 @@
                 {% if entry.algorithm.space_complexity %}<dt>space complexity</dt><dd>{{ entry.algorithm.space_complexity }}</dd>{% endif %}
             {% endcapture %}
             {% assign stripped_algorithm_data = algorithm_data | strip %}
-            {% if stripped_algorithm_data == "" %}
-                {{ entry.description }}
-            {% else %}
+            {% if entry.draft and stripped_algorithm_data != "" %}
                 <details class="algorithm-index-details">
                     <summary>
                         {{ entry.description }}
@@ -55,6 +53,8 @@
                         </dl>
                     </div>
                 </details>
+            {% else %}
+                {{ entry.description }}
             {% endif %}
         </dd>
     {% endunless %}


### PR DESCRIPTION
あると分かりやすいのでうれしい気がする。
「メタデータに計算量を追加します」というだけのプルリクが送りやすくなるのでその意味のうれしさもある。
しかし表示がごちゃごちゃするという点では微妙かもしれない。

画面のすっきりさを優先した結果、機能の存在がなんだか気づかれにくくなった気もする。小さな `▶` を見て `<details>` を感じるのはかなりパソコン力が要求されてそう。

プレビュー: https://kmyk.github.io/algorithm-encyclopedia-staging/#noredirect