### PR TITLE
KaTeX で display math が動いていなかった問題などを修正する

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,12 +15,22 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script defer>
       document.addEventListener("DOMContentLoaded", function() {
+        // This is workaround for `math_engine: mathjax` of GitHub Pages' Kramdown.
+        const scripts = [];
+        for (const script of document.getElementsByTagName("script")) {
+            if (script.type == "math/tex") {
+                scripts.push(script);
+            }
+        }
+        for (const script of scripts) {
+            const text = "$$" + script.textContent + "$$";
+            script.parentNode.replaceChild(document.createTextNode(text), script);
+        }
+        // Use $...$ and $$...$$ for LaTeX. Disable \(...\) and \[...\] to avoid the confusion with the escape of Markdown.
         renderMathInElement(document.body, {
           delimiters: [
             {left: "$$", right: "$$", display: true},
             {left: "$", right: "$", display: false},
-            {left: "\\(", right: "\\)", display: false},
-            {left: "\\[", right: "\\]", display: true},
           ],
         });
       });

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -100,7 +100,7 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
     if '</a>' not in msg:
         error_by_regex(
             pattern=r'\$.*[<>].*\$',
-            text=r"KaTeX: 数式中では `<` や `>` ではなく `\langre` や `\rangle` を使ってください。`<` や `>` は HTML のタグと解釈されて壊れることがあります。",
+            text=r"KaTeX: 数式中では `<` や `>` ではなく `\lt` や `gt` や `\langle` や `\rangle` を使ってください。`<` や `>` は HTML のタグと解釈されて壊れることがあります。",
         )
 
     users = list_defined_users()

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -98,6 +98,11 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
         pattern=r'\$.*\|.*\$',
         text=r"KaTeX: 絶対値記号などには `|` や `\|` ではなく `\vert` や `\lvert` `\rvert` を使ってください。`|` は Markdown のテーブルと解釈されて壊れることがあり、また `\|` は Markdown の処理系によっては HTML 上で `|` ではなく `\|` になって壊れることがあります。",
     )
+    if '</a>' not in msg:
+        error_by_regex(
+            pattern=r'\$.*[<>].*\$',
+            text=r"KaTeX: 数式中では `<` や `>` ではなく `\langre` や `\rangle` を使ってください。`<` や `>` は HTML のタグと解釈されて壊れることがあります。",
+        )
 
     users = list_defined_users()
     for m in re.finditer(r'<a +class="handle">(\w+)</a>', msg):

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -93,8 +93,7 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
         pattern=r'_{',
         text=r"KaTeX: `a_{i + 1}` ではなく `a _ {i + 1}` を使ってください。`_` のまわりに空白がないと、Markdown の強調と解釈されて壊れることがあります。",
     )
-    # 正しく表示されていればすぐに問題になるものではないので、作業中の記事を壊さないように warning にしておく。 TODO: しばらくしてから error にする。
-    warning_by_regex(
+    error_by_regex(
         pattern=r'\$.*\|.*\$',
         text=r"KaTeX: 絶対値記号などには `|` や `\|` ではなく `\vert` や `\lvert` `\rvert` を使ってください。`|` は Markdown のテーブルと解釈されて壊れることがあり、また `\|` は Markdown の処理系によっては HTML 上で `|` ではなく `\|` になって壊れることがあります。",
     )
@@ -266,12 +265,10 @@ def collect_messages_from_file(path: pathlib.Path) -> Iterator[Message]:
         yield from collect_messages_from_line(line, path=path, line=offset + i + 1)
 
     if not lines[-1].endswith('\n'):
-        # 正しく表示されていればすぐに問題になるものではないので、作業中の記事を壊さないように warning にしておく。 TODO: しばらくしてから error にする。
-        yield warning('file: ファイルの末尾には改行文字を付与してください。テキストファイルとは行を並べたものであり、行とは改行文字で終了するものです。実用的には、commit log に不要な修正が紛れ込むことを防ぐ効果があります。', file=path, line=len(lines), col=len(lines[-1]))
+        yield error('file: ファイルの末尾には改行文字を付与してください。テキストファイルとは行を並べたものであり、行とは改行文字で終了するものです。実用的には、commit log に不要な修正が紛れ込むことを防ぐ効果があります。', file=path, line=len(lines), col=len(lines[-1]))
     for i, line in enumerate(lines):
         if line.rstrip('\n').endswith(' '):
-            # 正しく表示されていればすぐに問題になるものではないので、作業中の記事を壊さないように warning にしておく。 TODO: しばらくしてから error にする。
-            yield warning('file: 行の末尾の空白文字は削除してください。Markdown の強制改行は使わないでください。', file=path, line=i + 1, col=len(line))
+            yield error('file: 行の末尾の空白文字は削除してください。また、Markdown の強制改行は使わないでください。', file=path, line=i + 1, col=len(line))
 
 
 def list_markdown_files() -> List[pathlib.Path]:

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -78,6 +78,10 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
     )
 
     error_by_regex(
+        pattern=r'^\$$',
+        text=r"KaTeX: display 表示をしたいときは `$` ではなく `$$` を使ってください。`$` は inline 表示になります。",
+    )
+    error_by_regex(
         pattern=r'\\\\',
         text=r"KaTeX: `\\` ではなく `\cr` を使ってください。`\\` が Markdown でのエスケープと解釈されて壊れることがあります。",
     )


### PR DESCRIPTION
display math のつもりで inline math を使っていたらエラーを出すようにもしたり、`<` や `>` を使っていたらエラーを出すようにもします。

@jupiro これが merge されたら `$ git fetch upstream gh-pages && git rebase upstream/gh-pages` として rebase してください。