### PR TITLE
Markdown のファイル名に大文字などが含まれていたらエラーにする

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -274,6 +274,13 @@ def collect_messages_from_yaml_frontmatter(frontmatter: Dict[str, Any], *, path:
 
 
 def collect_messages_from_file(path: pathlib.Path) -> Iterator[Message]:
+    if path.name != path.name.lower():
+        yield error('file: ファイルの basename はすべて小文字にしてください。', file=path, line=-1, col=-1)
+    if '_' in path.name:
+        yield error('file: ファイルの basename では `_` ではなく `-` を使ってください。', file=path, line=-1, col=-1)
+    if ' ' in path.name:
+        yield error('file: ファイルの basename では空白文字 ` ` ではなく `-` を使ってください。', file=path, line=-1, col=-1)
+
     with open(path) as fh:
         lines = list(fh.readlines())
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -303,6 +303,9 @@ def collect_messages_from_file(path: pathlib.Path) -> Iterator[Message]:
             break
     else:
         yield error('file: YAML frontmatter がありません。ファイルの2行目以降に `---` が見つかりませんでした。', file=path, line=-1, col=-1)
+    if not isinstance(frontmatter, dict):
+        yield error('file: YAML frontmatter は辞書であるべきです。', file=path, line=-1, col=-1)
+        return
 
     yield from collect_messages_from_yaml_frontmatter(frontmatter, path=path)
     for i, line in enumerate(body):


### PR DESCRIPTION
URL としても使われるので統一性がある方がよいです。

@noshi91 merge お願いします