### PR TITLE
KaTeX の表示が GitHub Pages 上でだけ壊れるやつを直す

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script defer>
       document.addEventListener("DOMContentLoaded", function() {
-        // This is workaround for `math_engine: mathjax` of GitHub Pages' Kramdown.
+        // This is workaround for `math_engine: mathjax` of GitHub Pages' Kramdown. Kramdown convert `$$ ... $$` to `<script type="math/tex"> ... <\/script>` on local environments.
         const scripts = [];
         for (const script of document.getElementsByTagName("script")) {
             if (script.type == "math/tex") {
@@ -26,11 +26,12 @@
             const text = "$$" + script.textContent + "$$";
             script.parentNode.replaceChild(document.createTextNode(text), script);
         }
-        // Use $...$ and $$...$$ for LaTeX. Disable \(...\) and \[...\] to avoid the confusion with the escape of Markdown.
+        // Use $...$ and $$...$$ for LaTeX.
         renderMathInElement(document.body, {
           delimiters: [
             {left: "$$", right: "$$", display: true},
             {left: "$", right: "$", display: false},
+            {left: "\\(", right: "\\)", display: true},  // I don't know why, but Kramdown convert `$$ ... $$` to `\( ... \)` on GitHub Pages.
           ],
         });
       });

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -89,6 +89,10 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
         text=r"KaTeX: inline 表示をしたいときは `\(` や `\)` ではなく `$` を使ってください。`\(` や `\)` は Markdown でのエスケープと解釈されて壊れることがあります。",
     )
     error_by_regex(
+        pattern=r'\\\[\|\\\]',
+        text=r"KaTeX: 数式中の角括弧には `\[` と `\]` ではなく `\lbrack` と `\rbrack` を使ってください。文章中の角括弧には `\[` と `\]` ではなく `&#091;` と `&#093;` を使ってください。display 表示をしたいときは `\[` と `\]` ではなく `$$` を使ってください。`\[` や `\]` は Markdown でのエスケープと解釈されて壊れることがあります。",
+    )
+    error_by_regex(
         pattern=r'^\$$',
         text=r"KaTeX: display 表示をしたいときは `$` ではなく `$$` を使ってください。`$` は inline 表示になります。",
     )

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -85,6 +85,10 @@ def collect_messages_from_line(msg: str, *, path: pathlib.Path, line: int) -> Li
     )
 
     error_by_regex(
+        pattern=r'\\\(\|\\\)',
+        text=r"KaTeX: inline 表示をしたいときは `\(` や `\)` ではなく `$` を使ってください。`\(` や `\)` は Markdown でのエスケープと解釈されて壊れることがあります。",
+    )
+    error_by_regex(
         pattern=r'^\$$',
         text=r"KaTeX: display 表示をしたいときは `$` ではなく `$$` を使ってください。`$` は inline 表示になります。",
     )


### PR DESCRIPTION
#102 #110 で @jupiro が困っている問題の修正です。
手元では再現しないが、GitHub Pages 上だと `$$ ... $$` が `\( ... \)` に変換されて壊れているようです。なぜ `\[ ... \]` でなく `\( ... \)` になるのかはまったく不明です。

プレビュー: https://kmyk.github.io/algorithm-encyclopedia-staging/johnson-algorithm#noredirect
@noshi91 問題なさそうなら、このプルリクと #110 とを両方 merge してしまってください